### PR TITLE
Ensure size is always a string

### DIFF
--- a/printers/printers.py
+++ b/printers/printers.py
@@ -60,7 +60,7 @@ def getData():
             ])
 
             if 'ERROR' in line:
-                job['size']  = 0
+                job['size']  = '0'
                 job['time']  = ''
                 job['error'] = line[line.index('ERROR'):]
             else:


### PR DESCRIPTION
Currently, when there's an error, the `size` key turns into a number when it's defined to be a string. This should fix that so it's always a string.